### PR TITLE
fix: pass selected model to SDK query

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -638,6 +638,7 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 
 			const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {
 				cwd,
+				model: model.id,
 				tools: sdkTools,
 				permissionMode: "dontAsk",
 				includePartialMessages: true,


### PR DESCRIPTION
## Summary
- pass the selected pi model (`model.id`) into Claude Agent SDK `query` options
- prevents SDK from silently falling back to Claude Code default model

## Repro
1. In pi, use provider `claude-agent-sdk` and select `claude-sonnet-4-6`.
2. Ask: `what model are you?`
3. Before this fix, assistant could reply with Opus (e.g. `claude-opus-4-6`) even though Sonnet is selected in UI.

<img width="547" height="171" alt="image" src="https://github.com/user-attachments/assets/011b9f93-0d0f-4bf8-b7a4-e2f049091aa0" />


## Root cause
`streamClaudeAgentSdk` built `queryOptions` without a `model` field, so SDK used default model from Claude Code settings/session.

## Fix
Add:
```ts
model: model.id
```
inside `queryOptions` before calling `query({ prompt, options: queryOptions })`.

## Validation
- local manual test: after patch, selecting Sonnet in pi returns Sonnet in assistant response
- mismatch no longer reproduced

<img width="1439" height="268" alt="image" src="https://github.com/user-attachments/assets/d23bfcf8-6a0a-4ab0-bb8a-f4999408bd8a" />

