### PR TITLE
Fix edit tool arg mapping to pi edits array

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -684,12 +684,33 @@ function mapToolArgs(
 				path: resolvePath(input.file_path ?? input.path),
 				content: input.content,
 			};
-		case "edit":
-			return {
-				path: resolvePath(input.file_path ?? input.path),
-				oldText: input.old_string ?? input.oldText ?? input.old_text,
-				newText: input.new_string ?? input.newText ?? input.new_text,
-			};
+		case "edit": {
+			const path = resolvePath(input.file_path ?? input.path);
+			const mappedEdits = Array.isArray(input.edits)
+				? input.edits
+						.map((item) => {
+							if (!item || typeof item !== "object") return null;
+							const editItem = item as Record<string, unknown>;
+							const oldText = editItem.oldText ?? editItem.old_string ?? editItem.old_text;
+							const newText = editItem.newText ?? editItem.new_string ?? editItem.new_text;
+							if (typeof oldText !== "string" || typeof newText !== "string") return null;
+							return { oldText, newText };
+						})
+						.filter((item): item is { oldText: string; newText: string } => item !== null)
+				: [];
+
+			if (mappedEdits.length > 0) {
+				return { path, edits: mappedEdits };
+			}
+
+			const oldText = input.old_string ?? input.oldText ?? input.old_text;
+			const newText = input.new_string ?? input.newText ?? input.new_text;
+			if (typeof oldText === "string" && typeof newText === "string") {
+				return { path, edits: [{ oldText, newText }] };
+			}
+
+			return { path, edits: mappedEdits };
+		}
 		case "bash":
 			return {
 				command: input.command,


### PR DESCRIPTION
**Disclaimer: 100% vibed but might be useful all the same**

---

With latest pi (0.66.1 as of now), model seemed unable to actually apply edits:

<img width="1279" height="599" alt="image" src="https://github.com/user-attachments/assets/f59b03d5-c470-4ddc-8125-edfb7fa47034" />

Codex vibed up this fix for me and claude sdk seems to work now. Of course it still thinks it can only do 1 edit per tool invocation (I assume because that is what the underlying claude sdk says). But it can actually edit again.