### PR TITLE
fix: use empty raw shape for inputSchema to fix SDK 0.2.107 compat

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -756,7 +756,10 @@ function buildCustomToolServers(customTools: Tool[]): Record<string, ReturnType<
 	const mcpTools = customTools.map((tool) => ({
 		name: tool.name,
 		description: tool.description,
-		inputSchema: tool.parameters as unknown,
+		// Pass empty raw shape instead of JSON Schema — the SDK (>=0.2.107)
+		// validates inputSchema as Zod or raw shape and rejects plain JSON Schema.
+		// These tool stubs are always denied anyway (pi executes tools, not the SDK).
+		inputSchema: {},
 		handler: async () => ({
 			content: [{ type: "text", text: TOOL_EXECUTION_DENIED_MESSAGE }],
 			isError: true,


### PR DESCRIPTION
## Problem

Starting Pi with MCP servers configured throws:

```
Error: inputSchema must be a Zod schema or raw shape, received an unrecognized object
```

## Cause

`buildCustomToolServers()` passes `tool.parameters` (a JSON Schema object from MCP tool definitions) as `inputSchema` to `createSdkMcpServer`. The Claude Agent SDK `>=0.2.107` introduced stricter validation that rejects anything that isn't a Zod schema or a "raw shape" (object whose values are Zod schemas). Plain JSON Schema objects like `{type: "object", properties: {...}}` are neither.

## Fix

Pass an empty object `{}` as `inputSchema` instead. The SDK accepts `{}` as a valid raw shape (empty object passes the `Object.keys().length === 0` check).

This is safe because these tool stubs always return `TOOL_EXECUTION_DENIED_MESSAGE` — Pi executes tools itself, not the SDK. The actual schema is irrelevant for denied tool stubs.

## Tested

- Verified Pi starts cleanly with MCP servers (codeindex, notebooklm, ai-pm-v2, ai-pataka-v2, cloudflare, telegram)
- Verified chat works end-to-end after the fix
- Verified against `@anthropic-ai/claude-agent-sdk@0.2.107`