### PR TITLE
feat: allow settingSources and strictMcpConfig with appendSystemPrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,16 @@ The provider automatically maps these back to the pi tool name (e.g. `subagent`)
    ln -s ~/.pi/agent/AGENTS.md ~/.claude/CLAUDE.md
    ln -s ~/.pi/agent/skills ~/.claude/skills
    ```
+
+3) **Append + full isolation**
+   - Pi skills in the prompt, but no settings/MCP inheritance from Claude Code.
+
+   ```json
+   {
+     "claudeAgentSdkProvider": {
+       "appendSystemPrompt": true,
+       "settingSources": [],
+       "strictMcpConfig": true
+     }
+   }
+   ```

--- a/index.ts
+++ b/index.ts
@@ -879,15 +879,14 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			const systemPromptAppend = appendParts.length > 0 ? appendParts.join("\n\n") : undefined;
 			const allowSkillAliasRewrite = Boolean(skillsAppend);
 
-			const settingSources: SettingSource[] | undefined = appendSystemPrompt
-				? undefined
-				: providerSettings.settingSources ?? ["user", "project"];
+			const settingSources: SettingSource[] | undefined = providerSettings.settingSources
+				?? (appendSystemPrompt ? undefined : ["user", "project"]);
 
 			// Claude Code will auto-load MCP servers from ~/.claude.json and .mcp.json when settingSources is enabled.
 			// In this provider, Claude Code tool execution is denied and pi executes tools instead, so auto-loaded MCP
 			// tools are pure token overhead. Pass --strict-mcp-config to ignore all MCP configs except those explicitly
 			// provided via the SDK (mcpServers option).
-			const strictMcpConfigEnabled = !appendSystemPrompt && providerSettings.strictMcpConfig !== false;
+			const strictMcpConfigEnabled = providerSettings.strictMcpConfig ?? !appendSystemPrompt;
 			const extraArgs = strictMcpConfigEnabled ? { "strict-mcp-config": null } : undefined;
 
 			const queryOptions: NonNullable<Parameters<typeof query>[0]["options"]> = {


### PR DESCRIPTION
## Summary

- `settingSources` and `strictMcpConfig` are now respected when explicitly set, regardless of `appendSystemPrompt`
- Enables "append + full isolation" config: pi skills in prompt with no Claude Code settings/MCP inheritance
- Default behavior unchanged

Closes #7