### PR TITLE
fix(#11): stop echoing role prefixes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -363,36 +363,40 @@ function buildPromptBlocks(
 
 	for (const message of context.messages) {
 		if (message.role === "user") {
-			pushPrefix("USER:");
+			pushPrefix('<message role="user">');
 			const hasText = appendContentBlocks(message.content);
 			if (!hasText) {
 				pushText("(see attached image)");
 			}
+			pushText("\n</message>");
 			continue;
 		}
 
 		if (message.role === "assistant") {
-			pushPrefix("ASSISTANT:");
+			pushPrefix('<message role="assistant">');
 			const text = contentToText(message.content, customToolNameToSdk);
 			if (text.length > 0) {
 				pushText(text);
 			}
+			pushText("\n</message>");
 			continue;
 		}
 
 		if (message.role === "toolResult") {
-			const header = `TOOL RESULT (historical ${mapPiToolNameToSdk(message.toolName, customToolNameToSdk)}, id=${message.toolCallId}):`;
-			pushPrefix(header);
+			const toolName = mapPiToolNameToSdk(message.toolName, customToolNameToSdk);
+			pushPrefix(`<tool_result tool_use_id="${message.toolCallId}" tool_name="${toolName}">`);
 			const hasText = appendContentBlocks(message.content);
 			if (!hasText) {
 				pushText("(see attached image)");
 			}
+			pushText("\n</tool_result>");
 		}
 	}
 
 	if (toolWatchNote && toolWatchNote.trim().length > 0) {
-		pushPrefix("RECOVERED TOOL RESULTS:");
+		pushPrefix("<recovered_tool_results>");
 		pushText(toolWatchNote.trim());
+		pushText("\n</recovered_tool_results>");
 	}
 
 	if (!blocks.length) return [{ type: "text", text: "" }];
@@ -425,6 +429,7 @@ function contentToText(
 			type: string;
 			text?: string;
 			thinking?: string;
+			id?: string;
 			name?: string;
 			arguments?: Record<string, unknown>;
 		}>,
@@ -435,11 +440,12 @@ function contentToText(
 	return content
 		.map((block) => {
 			if (block.type === "text") return block.text ?? "";
-			if (block.type === "thinking") return block.thinking ?? "";
+			if (block.type === "thinking") return `<thinking>\n${block.thinking ?? ""}\n</thinking>`;
 			if (block.type === "toolCall") {
 				const args = block.arguments ? JSON.stringify(block.arguments) : "{}";
 				const toolName = mapPiToolNameToSdk(block.name, customToolNameToSdk);
-				return `Historical tool call (non-executable): ${toolName} args=${args}`;
+				const idAttr = block.id ? ` id="${block.id}"` : "";
+				return `<tool_use${idAttr} name="${toolName}">${args}</tool_use>`;
 			}
 			return `[${block.type}]`;
 		})
@@ -1256,3 +1262,8 @@ export default function (pi: ExtensionAPI) {
 		streamSimple: streamClaudeAgentSdk,
 	});
 }
+
+export const __test = {
+	buildPromptBlocks,
+	contentToText,
+};

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "pi-package"
   ],
   "type": "module",
+  "scripts": {
+    "test": "node --test tests/**/*.test.ts"
+  },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.126",
     "@anthropic-ai/sdk": "^0.73.0",

--- a/tests/session-resume-behavior.test.ts
+++ b/tests/session-resume-behavior.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert";
+import { describe, test } from "node:test";
+import { __test } from "../index.ts";
+
+const { buildPromptBlocks, contentToText } = __test;
+
+describe("buildPromptBlocks", () => {
+	test("uses XML tags, not echoable prefixes", () => {
+		const messages = [
+			{ role: "user" as const, content: "hello", timestamp: 1 },
+			{
+				role: "assistant" as const,
+				content: [
+					{ type: "text" as const, text: "hi" },
+					{ type: "toolCall" as const, id: "toolu_1", name: "read", arguments: { path: "a" } },
+					{ type: "thinking" as const, thinking: "planning..." },
+				],
+				api: "anthropic-messages" as const,
+				provider: "claude-agent-sdk" as const,
+				model: "claude-opus-4-6",
+				usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } },
+				stopReason: "toolUse" as const,
+				timestamp: 2,
+			},
+			{ role: "toolResult" as const, toolCallId: "toolu_1", toolName: "Read", content: "content", isError: false, timestamp: 3 },
+		];
+
+		const blocks = buildPromptBlocks({ messages, systemPrompt: undefined }, undefined);
+		const text = blocks.filter((b: any) => b.type === "text").map((b: any) => b.text).join("");
+
+		assert.equal(text.includes("ASSISTANT:"), false, "must not contain ASSISTANT: prefix");
+		assert.equal(text.includes("USER:"), false, "must not contain USER: prefix");
+		assert.equal(text.includes("Historical tool call (non-executable)"), false, "must not contain Historical tool call prefix");
+		assert.equal(text.includes("TOOL RESULT (historical"), false, "must not contain TOOL RESULT prefix");
+
+		assert.ok(text.includes('<message role="user">\nhello\n</message>'), "user message wrapped in XML");
+		assert.ok(text.includes('<message role="assistant">'), "assistant message wrapped in XML");
+		assert.ok(text.includes('<tool_use id="toolu_1" name="Read">{"path":"a"}</tool_use>'), "tool call in XML");
+		assert.ok(text.includes('<thinking>\nplanning...\n</thinking>'), "thinking in XML");
+		assert.ok(text.includes('<tool_result tool_use_id="toolu_1" tool_name="Read">\ncontent\n</tool_result>'), "tool result in XML");
+	});
+});
+
+describe("contentToText", () => {
+	test("formats toolCall and thinking as XML", () => {
+		const content = [
+			{ type: "text" as const, text: "hi" },
+			{ type: "toolCall" as const, id: "t1", name: "read", arguments: { path: "x" } },
+			{ type: "thinking" as const, thinking: "think" },
+		];
+		const text = contentToText(content);
+		assert.ok(text.includes('<tool_use id="t1" name="Read">{"path":"x"}</tool_use>'));
+		assert.ok(text.includes('<thinking>\nthink\n</thinking>'));
+		assert.equal(text.includes("Historical tool call (non-executable)"), false);
+	});
+});


### PR DESCRIPTION
## Summary
- Wrap history turns in XML tags (`<message role>`, `<tool_use>`, `<tool_result>`, `<thinking>`, `<recovered_tool_results>`) instead of the echoable `USER:`/`ASSISTANT:`/`Historical tool call`/`TOOL RESULT` prefixes, so the model stops hallucinating them into its output.
- Adds regression tests asserting the rendered prompt contains XML tags and none of the legacy prefixes.

Fixes #11.
