### PR TITLE
fix: raise CLAUDE_CODE_MAX_OUTPUT_TOKENS and cap thinking budgets per model

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -756,6 +756,12 @@ const DEFAULT_THINKING_BUDGETS: Record<NonXhighThinkingLevel, number> = {
 	high: 31999,
 };
 
+// Claude Code's default output token maximum (covers thinking + text combined).
+// Must be raised when thinking budgets approach or exceed this ceiling.
+const CLAUDE_CODE_DEFAULT_MAX_OUTPUT_TOKENS = 32000;
+// Headroom for text output on top of the thinking budget.
+const TEXT_OUTPUT_HEADROOM_TOKENS = 16384;
+
 // NOTE: "xhigh" is unavailable in the TUI because pi-ai's supportsXhigh()
 // doesn't recognize the "claude-agent-sdk" api type. As a workaround, opus-4-6
 // gets shifted budgets so "high" uses the budget that xhigh would normally use.
@@ -980,10 +986,58 @@ function streamClaudeAgentSdk(model: Model<any>, context: Context, options?: Sim
 			if (options?.reasoning && supportsAdaptiveThinking(model.id)) {
 				queryOptions.thinking = { type: "adaptive", display: "summarized" } satisfies ThinkingConfig;
 				queryOptions.effort = mapThinkingLevelToEffort(model, options.reasoning);
-			} else {
-				const maxThinkingTokens = mapThinkingTokens(options?.reasoning, model.id, options?.thinkingBudgets);
+			} else if (options?.reasoning) {
+				let maxThinkingTokens = mapThinkingTokens(options.reasoning, model.id, options?.thinkingBudgets);
 				if (maxThinkingTokens != null) {
+					// Cap the thinking budget so it leaves room for text output within the
+					// model's actual API max output limit. Models like opus-4-0 and opus-4-1
+					// have a 32k API max — assigning 31,999 thinking tokens leaves no room.
+					const apiMaxTokens = model.maxTokens ?? Number.MAX_SAFE_INTEGER;
+					const cappedBudget = Math.min(maxThinkingTokens, apiMaxTokens - TEXT_OUTPUT_HEADROOM_TOKENS);
+					if (cappedBudget < maxThinkingTokens) {
+						maxThinkingTokens = cappedBudget;
+					}
 					queryOptions.maxThinkingTokens = maxThinkingTokens;
+				}
+			}
+
+			// When thinking is enabled, the combined thinking + text output can exceed
+			// Claude Code's default 32k output token ceiling. Raise the limit via env
+			// so the CLI doesn't error with "response exceeded the 32000 output token
+			// maximum". Only raise the value — never lower a user-supplied override.
+			//
+			// For adaptive thinking models, we don't know the actual token budget at
+			// request time — the model decides dynamically. Set the ceiling to the
+			// model's API max output so adaptive thinking has full headroom.
+			if (options?.reasoning) {
+				let requiredMax: number | undefined;
+
+				if (supportsAdaptiveThinking(model.id)) {
+					// Adaptive thinking: use the model's full API max output as the ceiling.
+					const apiMaxTokens = model.maxTokens ?? Number.MAX_SAFE_INTEGER;
+					if (apiMaxTokens > CLAUDE_CODE_DEFAULT_MAX_OUTPUT_TOKENS) {
+						requiredMax = apiMaxTokens;
+					}
+				} else {
+					// Manual thinking: derive from budget + text headroom.
+					const budget = mapThinkingTokens(options.reasoning, model.id, options?.thinkingBudgets);
+					if (budget != null) {
+						const candidate = budget + TEXT_OUTPUT_HEADROOM_TOKENS;
+						if (candidate > CLAUDE_CODE_DEFAULT_MAX_OUTPUT_TOKENS) {
+							requiredMax = candidate;
+						}
+					}
+				}
+
+				if (requiredMax != null) {
+					const existingRaw = process.env.CLAUDE_CODE_MAX_OUTPUT_TOKENS;
+					const existing = existingRaw != null ? Number(existingRaw) : undefined;
+					if (!Number.isFinite(existing) || existing < requiredMax) {
+						queryOptions.env = {
+							...process.env,
+							CLAUDE_CODE_MAX_OUTPUT_TOKENS: String(requiredMax),
+						};
+					}
 				}
 			}
 


### PR DESCRIPTION
## Problem

Claude Code enforces a default 32,000 output token maximum that covers thinking and text output combined. The extension configures thinking budgets that approach or exceed this ceiling without raising it. Additionally, some budgets exceed the model's hard API max output.

This causes the error:

```
Error: Claude Code returned an error result: API Error: Claude's response exceeded the 32000 output token maximum. To configure this behavior, set the CLAUDE_CODE_MAX_OUTPUT_TOKENS environment variable.
```

### Issue 1: `CLAUDE_CODE_MAX_OUTPUT_TOKENS` never raised

Every model with reasoning enabled at medium+ exceeds the 32k CLI default:

| Model | Level | Thinking budget | Required max |
|---|---|---|---|
| opus-4-7 | medium+ | 16,384+ | 32,768+ |
| opus-4-6 | medium | 31,999 | 48,383 |
| opus-4-6 | high/xhigh | 63,999 | 80,383 |
| opus-4-5, sonnet-4-6, etc. | medium+ | 16,384+ | 32,768+ |

### Issue 2: Thinking budgets exceed model API max output

Opus 4.0 and 4.1 have a **32k hard API max output**. Setting 31,999 thinking tokens leaves only 1 for text — any response will fail regardless of the CLI env var.

| Model | API max | "high" budget | Room for text |
|---|---|---|---|
| opus-4-0 | 32,000 | 31,999 | 1 token |
| opus-4-1 | 32,000 | 31,999 | 1 token |

### Issue 3: Adaptive thinking uses more tokens than the mapped budget estimate

The original fix used `mapThinkingTokens()` as an upper-bound estimate for adaptive thinking models. But adaptive thinking dynamically decides how many tokens to use — at high/xhigh/max effort, models can use far more than the static budget:

| Model | API max | Mapped budget | Old `CLAUDE_CODE_MAX` | Actual possible |
|---|---|---|---|---|
| opus-4-7 | 128,000 | 31,999 | 48,383 | up to 128,000 |
| opus-4-6 | 128,000 | 63,999 | 80,383 | up to 128,000 |
| sonnet-4-6 | 64,000 | 31,999 | 48,383 | up to 64,000 |

Anthropic docs confirm: *"When running Claude Opus 4.7 at xhigh or max effort, set a large max_tokens so the model has room to think and act across subagents and tool calls. Starting at 64k tokens and tuning from there is a reasonable default."*

## Fix (three parts)

### 1. For adaptive thinking models: set `CLAUDE_CODE_MAX_OUTPUT_TOKENS` to `model.maxTokens`

When using `thinking: { type: "adaptive" }`, the model decides its own budget at runtime. Set the CLI ceiling to the model's actual API max output so adaptive thinking always has full headroom.

### 2. For manual thinking models: derive from budget + headroom

When using `maxThinkingTokens`, compute `budget + 16384` and raise the CLI ceiling when it exceeds 32k.

### 3. Cap `maxThinkingTokens` against the model's API max

Before passing `maxThinkingTokens` to the SDK, cap it to `model.maxTokens - 16384` so there is always room for text output. This prevents budgets like 31,999 on models with only 32k max output.

## Testing

- `tsc --noEmit` passes cleanly
- Only `index.ts` changed

## Model coverage

| Model | Adaptive? | Fix applied |
|---|---|---|
| opus-4-7 | ✅ adaptive only | `CLAUDE_CODE_MAX_OUTPUT_TOKENS` = 128,000 |
| opus-4-6 | ✅ adaptive | `CLAUDE_CODE_MAX_OUTPUT_TOKENS` = 128,000 |
| sonnet-4-6 | ✅ adaptive | `CLAUDE_CODE_MAX_OUTPUT_TOKENS` = 64,000 |
| opus-4-5 | manual | budget capped + env raised |
| opus-4-1 | manual | budget capped to 15,616 + env raised |
| opus-4-0 | manual | budget capped to 15,616 + env raised |
| sonnet-4-5 | manual | budget capped + env raised |
| haiku-4-5 | manual | budget capped + env raised |
| claude-3-7-sonnet | manual | budget capped + env raised |