### PR TITLE
ci: add type-check workflow for Node 20 and 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22, 24, 26]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
       "devDependencies": {
         "@mariozechner/pi-ai": "^0.72.1",
         "@mariozechner/pi-coding-agent": "^0.72.1",
-        "@types/node": "^24.3.0"
+        "@types/node": "^24.3.0",
+        "typescript": "6.0.3"
       },
       "peerDependencies": {
         "@mariozechner/pi-ai": "^0.72.1",
@@ -4725,6 +4726,20 @@
       "integrity": "sha512-jb7jp6KvOvvy5sd+11AfJ0/e0F0AS9RcOXd55oGi2ZnRHIGmFvrTaNF+ZidRmGBmmNTkM5KKl0Z37KzxJ+owEQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "devDependencies": {
     "@mariozechner/pi-ai": "^0.72.1",
     "@mariozechner/pi-coding-agent": "^0.72.1",
-    "@types/node": "^24.3.0"
+    "@types/node": "^24.3.0",
+    "typescript": "6.0.3"
   },
   "pi": {
     "extensions": [


### PR DESCRIPTION
Runs `tsc --noEmit` on push and pull requests against master, testing both Node 20 and 22.