### PR TITLE
ci: add dependabot config with 7-day cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    versioning-strategy: increase
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Configures weekly dependency updates for npm and GitHub Actions. Both ecosystems have a 7-day cooldown using Dependabot's native `cooldown.default-days` option to avoid proposing updates for packages/actions published less than 7 days ago (catches retracted releases, yanked actions, and rapid-fire patches).